### PR TITLE
feat: drone swarm telemetry tuning — configurable timeouts, queue capacity, sync fix, shutdown()

### DIFF
--- a/CHANGES_FOR_DRONE_SWARM.md
+++ b/CHANGES_FOR_DRONE_SWARM.md
@@ -125,6 +125,42 @@ is unchanged; `Custom` users now get the value they asked for.
 
 ---
 
+### 4  `Core::shutdown()` — abort background tasks to release TCP listeners  (`src/core/mod.rs`)
+
+**What changed**
+
+`build()` spawns two long-lived background tasks:
+- `handle_async_operations` — owns the libp2p `Swarm` (and thus the TCP/UDP listeners)
+- `handle_network_response` — processes responses from the swarm back to the app
+
+Previously there was no way to stop these tasks. Dropping `Core` had no effect on
+them because they held independent `Arc`-cloned state. This meant a node could not
+release its listening port until the process exited — making port reuse (e.g. a
+drone rejoining from the same address) impossible in tests.
+
+**Fix**: store `tokio::task::AbortHandle`s in a shared `Arc<Mutex<Vec<AbortHandle>>>`
+field on `Core`, captured immediately after `tokio::task::spawn`. A new method:
+
+```rust
+#[cfg(feature = "tokio-runtime")]
+pub async fn shutdown(&self)
+```
+
+aborts all stored handles, releasing the swarm and its listeners synchronously.
+
+**Usage in ds-swarm**: called in the event loop's shutdown arm after `GossipsubExitNetwork`:
+
+```rust
+core.query_network(AppData::GossipsubExitNetwork(topic)).await;
+core.shutdown().await;  // ← releases TCP port immediately
+```
+
+**Why this is safe to upstream**: purely additive, tokio-runtime only, no behaviour
+change unless `shutdown()` is explicitly called.  Any user who needs clean shutdown
+semantics (graceful restart, port reuse) benefits from this.
+
+---
+
 ## What Was Not Changed
 
 - Transport layer (TCP/QUIC).  The `ds-sim` crate handles simulation by assigning

--- a/CHANGES_FOR_DRONE_SWARM.md
+++ b/CHANGES_FOR_DRONE_SWARM.md
@@ -1,0 +1,160 @@
+# Changes for Drone Swarm Integration
+
+Branch: `feature/drone-swarm-telemetry-tuning`
+Parent repo: https://github.com/algorealmInc/SwarmNL
+
+---
+
+## Why This Fork Exists
+
+The `ds-swarm` crate in the `nephilim` drone swarm project uses SwarmNL as its
+networking backbone.  The original library was designed for general-purpose
+decentralised applications and was not tuned for high-frequency telemetry
+workloads.  Three concrete problems blocked the integration:
+
+1. The response-polling loop in `recv_from_network` slept for a **hardcoded 3 s**
+   between retries, making every gossip publish call wait up to 30 s.  At a 200 ms
+   gossip interval this is two orders of magnitude too slow.
+
+2. The internal network event queue had a **hardcoded capacity of 300** elements.
+   Fifty drones gossiping at 200 ms each generate ~250 events/s network-wide.  Under
+   partition-recovery bursts the queue would overflow and silently drop events.
+
+3. The eventual-consistency replication background task slept for the **hardcoded
+   constant `SYNC_WAIT_TIME` (5 s)** even when a shorter `sync_wait_time` was
+   provided via `ReplNetworkConfig::Custom`.  The user-supplied value was stored but
+   never read by the sleep call — a silent bug.
+
+---
+
+## Changes
+
+### 1  Configurable `recv_from_network` timeout  (`src/core/prelude.rs`, `src/core/mod.rs`)
+
+**What changed**
+
+Replaced the two hardcoded constants `NETWORK_READ_TIMEOUT = 30` and
+`TASK_SLEEP_DURATION = 3` (seconds) with two configurable values stored on
+`NetworkInfo`:
+
+| Field | Default | Meaning |
+|---|---|---|
+| `network_recv_max_polls` | 10 | retries before `NetworkReadTimeout` |
+| `network_recv_poll_interval_ms` | 3 000 ms | sleep between retries |
+
+Effective ceiling: `max_polls × poll_interval_ms` ms (default: 30 s, unchanged).
+
+**New API**
+
+```rust
+CoreBuilder::with_network_timeout(max_polls: usize, poll_interval_ms: u64) -> Self
+```
+
+**Recommended setting for drone swarm**
+
+```rust
+// 50 polls × 100 ms = 5 s ceiling, 100 ms granularity
+builder.with_network_timeout(50, 100)
+```
+
+**Also fixed**: the original `recv_from_network` held the `stream_response_buffer`
+`MutexGuard` across the `sleep` call, blocking other tasks from writing responses
+into the buffer.  The guard is now dropped explicitly before sleeping.
+
+**Why this is safe to upstream**: purely additive — defaults are identical to the
+old behaviour.
+
+---
+
+### 2  Configurable event queue capacity  (`src/core/prelude.rs`, `src/core/mod.rs`)
+
+**What changed**
+
+`DataQueue` previously used a hardcoded capacity of 300 elements (via
+`MAX_QUEUE_ELEMENTS`) that could not be adjusted at runtime.  The struct now
+stores a `capacity: usize` field set at construction time.
+
+Added `DataQueue::with_capacity(capacity: usize) -> Self`.  The existing
+`DataQueue::new()` retains its default of 300 (via `DEFAULT_EVENT_QUEUE_CAPACITY`).
+
+**New API**
+
+```rust
+CoreBuilder::with_event_queue_capacity(capacity: usize) -> Self
+```
+
+**Recommended setting for drone swarm**
+
+```rust
+// 50 drones × ~20 events/s burst = 1 000 headroom
+builder.with_event_queue_capacity(2000)
+```
+
+**Why this is safe to upstream**: purely additive — defaults are identical to the
+old behaviour.
+
+---
+
+### 3  Fix `sync_wait_time` ignored in eventual-consistency loop  (`src/core/replication.rs`)
+
+**What changed**
+
+`ReplicaBufferQueue::sync_with_eventual_consistency` ended each iteration with:
+
+```rust
+tokio::time::sleep(Duration::from_secs(Self::SYNC_WAIT_TIME)).await;
+```
+
+`Self::SYNC_WAIT_TIME` is the constant `5`.  When a caller configured
+`ReplNetworkConfig::Custom { sync_wait_time: 1, .. }` the shorter interval was
+stored in the config but never applied — the loop always slept 5 s.
+
+**Fix**: read `sync_wait_time` from `self.config` before the sleep, matching the
+pattern already used for `data_aging_period` in the same function:
+
+```rust
+let sync_wait_time = match self.config {
+    ReplNetworkConfig::Default => Self::SYNC_WAIT_TIME,
+    ReplNetworkConfig::Custom { sync_wait_time, .. } => sync_wait_time,
+};
+tokio::time::sleep(Duration::from_secs(sync_wait_time)).await;
+```
+
+**Why this is safe to upstream**: bug fix — `ReplNetworkConfig::Default` behaviour
+is unchanged; `Custom` users now get the value they asked for.
+
+---
+
+## What Was Not Changed
+
+- Transport layer (TCP/QUIC).  The `ds-sim` crate handles simulation by assigning
+  unique localhost ports to each `SwarmNode` instance and having them dial a
+  known seed node directly.  No memory transport is required.
+- Gossipsub configuration (fanout, heartbeat intervals) — left at libp2p defaults.
+  These can be tuned via `CoreBuilder::with_gossipsub(GossipsubConfig::Custom {...})`
+  if propagation latency becomes an issue at >50 nodes.
+- Sharding and strong-consistency replication — not used by `ds-swarm`.
+
+---
+
+## Upstream PR Candidates
+
+All three changes are general-purpose improvements with no drone-specific logic.
+They are each good upstream PR candidates:
+
+- **PR 1** — "Make recv_from_network polling interval and retry count configurable"
+- **PR 2** — "Make DataQueue event-queue capacity configurable at build time"
+- **PR 3** — "Fix: ReplNetworkConfig::Custom sync_wait_time ignored in eventual-consistency loop"
+
+---
+
+## How to Point `ds-swarm` at This Fork
+
+```toml
+# ds-swarm/Cargo.toml
+[dependencies]
+swarm-nl = {
+  git = "https://github.com/<your-fork>/SwarmNL",
+  branch = "feature/drone-swarm-telemetry-tuning"
+}
+```

--- a/swarm-nl/src/core/mod.rs
+++ b/swarm-nl/src/core/mod.rs
@@ -728,6 +728,8 @@ impl CoreBuilder {
 			event_queue: DataQueue::with_capacity(self.event_queue_capacity),
 			replica_buffer: Arc::new(ReplicaBufferQueue::new(self.replication_cfg.clone())),
 			network_info,
+			#[cfg(feature = "tokio-runtime")]
+			task_handles: Arc::new(Mutex::new(Vec::new())),
 		};
 
 		// Check if sharding is configured
@@ -754,12 +756,15 @@ impl CoreBuilder {
 
 		// Spin up task to handle async operations and data on the network
 		#[cfg(feature = "tokio-runtime")]
-		tokio::task::spawn(Core::handle_async_operations(
-			swarm,
-			network_sender,
-			network_receiver,
-			network_core.clone(),
-		));
+		{
+			let handle = tokio::task::spawn(Core::handle_async_operations(
+				swarm,
+				network_sender,
+				network_receiver,
+				network_core.clone(),
+			));
+			network_core.task_handles.lock().await.push(handle.abort_handle());
+		}
 
 		// Spin up task to listen for responses from the network layer
 		#[cfg(feature = "async-std-runtime")]
@@ -770,10 +775,13 @@ impl CoreBuilder {
 
 		// Spin up task to listen for responses from the network layer
 		#[cfg(feature = "tokio-runtime")]
-		tokio::task::spawn(Core::handle_network_response(
-			application_receiver,
-			network_core.clone(),
-		));
+		{
+			let handle = tokio::task::spawn(Core::handle_network_response(
+				application_receiver,
+				network_core.clone(),
+			));
+			network_core.task_handles.lock().await.push(handle.abort_handle());
+		}
 
 		// Wait for a few seconds before passing control to the application
 		#[cfg(feature = "async-std-runtime")]
@@ -813,6 +821,10 @@ pub struct Core {
 	replica_buffer: Arc<ReplicaBufferQueue>,
 	/// Important information about the network
 	network_info: NetworkInfo,
+	/// Abort handles for background tasks spawned by `build()`. Shared across `Core` clones so
+	/// that any clone can abort all tasks (and release the TCP listener) via `shutdown()`.
+	#[cfg(feature = "tokio-runtime")]
+	task_handles: Arc<Mutex<Vec<tokio::task::AbortHandle>>>,
 }
 
 impl Core {
@@ -896,6 +908,16 @@ impl Core {
 	/// Return the node's `PeerId`.
 	pub fn peer_id(&self) -> PeerId {
 		self.keypair.public().to_peer_id()
+	}
+
+	/// Abort all background tasks spawned by `build()`, releasing the TCP/UDP listeners
+	/// immediately. Call this before dropping the last `Core` clone when you need the
+	/// port to be available for re-use (e.g. in tests, or on graceful shutdown).
+	#[cfg(feature = "tokio-runtime")]
+	pub async fn shutdown(&self) {
+		for handle in self.task_handles.lock().await.iter() {
+			handle.abort();
+		}
 	}
 
 	/// Return an iterator to the buffered network layer events and consume them.

--- a/swarm-nl/src/core/mod.rs
+++ b/swarm-nl/src/core/mod.rs
@@ -136,7 +136,7 @@ pub struct CoreBuilder {
 	/// The size of the stream buffers to use to track application requests to the network layer
 	/// internally.
 	stream_size: usize,
-	/// The IP address to listen on.f
+	/// The IP address to listen on.
 	ip_address: IpAddr,
 	/// Connection keep-alive duration while idle.
 	keep_alive_duration: Seconds,
@@ -163,6 +163,14 @@ pub struct CoreBuilder {
 	/// The name of the entire shard network. This is important for quick broadcasting of changes
 	/// in the shard network as a whole.
 	sharding: ShardingInfo,
+	/// Maximum number of polls in [`Core::recv_from_network`] before returning
+	/// [`NetworkError::NetworkReadTimeout`]. Effective timeout = `network_recv_max_polls ×
+	/// network_recv_poll_interval_ms` ms.
+	network_recv_max_polls: usize,
+	/// Milliseconds to sleep between each poll in [`Core::recv_from_network`].
+	network_recv_poll_interval_ms: u64,
+	/// Maximum number of events the internal event queue can hold before evicting the oldest.
+	event_queue_capacity: usize,
 }
 
 impl CoreBuilder {
@@ -240,6 +248,9 @@ impl CoreBuilder {
 				local_storage: Arc::new(Mutex::new(DefaultShardStorage)),
 				state: Default::default(),
 			},
+			network_recv_max_polls: DEFAULT_RECV_MAX_POLLS,
+			network_recv_poll_interval_ms: DEFAULT_RECV_POLL_INTERVAL_MS,
+			event_queue_capacity: DEFAULT_EVENT_QUEUE_CAPACITY,
 		}
 	}
 
@@ -383,6 +394,36 @@ impl CoreBuilder {
 	/// Configure the transports to support.
 	pub fn with_transports(self, transport: TransportOpts) -> Self {
 		CoreBuilder { transport, ..self }
+	}
+
+	/// Configure the polling behaviour of [`Core::recv_from_network`].
+	///
+	/// `max_polls` is the number of retries before [`NetworkError::NetworkReadTimeout`] is
+	/// returned.  `poll_interval_ms` is the sleep duration between retries in **milliseconds**.
+	/// The effective ceiling on wait time is `max_polls × poll_interval_ms` ms.
+	///
+	/// **Default:** 10 polls × 3 000 ms = 30 s.  For 200 ms gossip workloads a value of
+	/// `(50, 100)` (5 s ceiling, 100 ms granularity) is recommended.
+	pub fn with_network_timeout(self, max_polls: usize, poll_interval_ms: u64) -> Self {
+		CoreBuilder {
+			network_recv_max_polls: max_polls,
+			network_recv_poll_interval_ms: poll_interval_ms,
+			..self
+		}
+	}
+
+	/// Configure the capacity of the internal network event queue.
+	///
+	/// When the queue is full the **oldest** event is evicted to make room for the new one.
+	/// Increase this value for workloads that generate many events in short bursts (e.g. 50+
+	/// drones gossiping at 200 ms intervals).
+	///
+	/// **Default:** [`DEFAULT_EVENT_QUEUE_CAPACITY`] (300).
+	pub fn with_event_queue_capacity(self, capacity: usize) -> Self {
+		CoreBuilder {
+			event_queue_capacity: capacity,
+			..self
+		}
 	}
 
 	/// Return the id of the network.
@@ -672,6 +713,8 @@ impl CoreBuilder {
 			gossip_filter_fn: self.gossipsub.1,
 			replication: repl_info,
 			sharding: self.sharding.clone(),
+			network_recv_max_polls: self.network_recv_max_polls,
+			network_recv_poll_interval_ms: self.network_recv_poll_interval_ms,
 		};
 
 		// Build the network core
@@ -681,8 +724,8 @@ impl CoreBuilder {
 			stream_request_buffer: stream_request_buffer.clone(),
 			stream_response_buffer: stream_response_buffer.clone(),
 			current_stream_id: Arc::new(Mutex::new(stream_id)),
-			// Initialize an empty event queue
-			event_queue: DataQueue::new(),
+			// Initialize event queue with the configured capacity
+			event_queue: DataQueue::with_capacity(self.event_queue_capacity),
 			replica_buffer: Arc::new(ReplicaBufferQueue::new(self.replication_cfg.clone())),
 			network_info,
 		};
@@ -930,33 +973,35 @@ impl Core {
 	/// This function is decoupled from the [`Core::send_to_network()`] method so as to prevent
 	/// blocking until the response is returned.
 	pub async fn recv_from_network(&mut self, stream_id: StreamId) -> NetworkResult<AppResponse> {
+		let max_polls = self.network_info.network_recv_max_polls;
+		let poll_interval_ms = self.network_info.network_recv_poll_interval_ms;
+
 		#[cfg(feature = "async-std-runtime")]
 		{
 			let channel = self.clone();
 			let response_handler = async_std::task::spawn(async move {
 				let mut loop_count = 0;
 				loop {
-					// Attempt to acquire the lock without blocking
-					let mut buffer_guard = channel.stream_response_buffer.lock().await;
+					// Acquire the lock, check for a result, then release before sleeping.
+					let result = {
+						let mut buffer_guard = channel.stream_response_buffer.lock().await;
+						buffer_guard.remove(&stream_id)
+					};
 
-					// Check if the value is available in the response buffer
-					if let Some(result) = buffer_guard.remove(&stream_id) {
+					if let Some(result) = result {
 						return Ok(result);
 					}
 
-					// Timeout after 10 trials
-					if loop_count < 10 {
+					if loop_count < max_polls {
 						loop_count += 1;
 					} else {
 						return Err(NetworkError::NetworkReadTimeout);
 					}
 
-					// Response has not arrived, sleep and retry
-					async_std::task::sleep(Duration::from_secs(TASK_SLEEP_DURATION)).await;
+					async_std::task::sleep(Duration::from_millis(poll_interval_ms)).await;
 				}
 			});
 
-			// Wait for the spawned task to complete
 			match response_handler.await {
 				Ok(result) => result,
 				Err(_) => Err(NetworkError::NetworkReadTimeout),
@@ -969,27 +1014,26 @@ impl Core {
 			let response_handler = tokio::task::spawn(async move {
 				let mut loop_count = 0;
 				loop {
-					// Attempt to acquire the lock without blocking
-					let mut buffer_guard = channel.stream_response_buffer.lock().await;
+					// Acquire the lock, check for a result, then release before sleeping.
+					let result = {
+						let mut buffer_guard = channel.stream_response_buffer.lock().await;
+						buffer_guard.remove(&stream_id)
+					};
 
-					// Check if the value is available in the response buffer
-					if let Some(result) = buffer_guard.remove(&stream_id) {
+					if let Some(result) = result {
 						return Ok(result);
 					}
 
-					// Timeout after 10 trials
-					if loop_count < 10 {
+					if loop_count < max_polls {
 						loop_count += 1;
 					} else {
 						return Err(NetworkError::NetworkReadTimeout);
 					}
 
-					// Response has not arrived, sleep and retry
-					tokio::time::sleep(Duration::from_secs(TASK_SLEEP_DURATION)).await;
+					tokio::time::sleep(Duration::from_millis(poll_interval_ms)).await;
 				}
 			});
 
-			// Wait for the spawned task to complete
 			match response_handler.await {
 				Ok(result) => result?,
 				Err(_) => Err(NetworkError::NetworkReadTimeout),

--- a/swarm-nl/src/core/prelude.rs
+++ b/swarm-nl/src/core/prelude.rs
@@ -14,17 +14,19 @@ use thiserror::Error;
 
 use super::*;
 
-/// The duration (in seconds) to wait for response from the network layer before timing
-/// out.
-pub const NETWORK_READ_TIMEOUT: Seconds = 30;
+/// Default maximum number of polls in [`Core::recv_from_network`] before returning
+/// [`NetworkError::NetworkReadTimeout`]. Effective timeout = `DEFAULT_RECV_MAX_POLLS ×
+/// DEFAULT_RECV_POLL_INTERVAL_MS` ms. Configurable via
+/// [`CoreBuilder::with_network_timeout`].
+pub const DEFAULT_RECV_MAX_POLLS: usize = 10;
 
-/// The time it takes for the task to sleep before it can recheck if an output has been placed in
-/// the response buffer.
-pub const TASK_SLEEP_DURATION: Seconds = 3;
+/// Default sleep between polls in [`Core::recv_from_network`], in milliseconds.
+/// Configurable via [`CoreBuilder::with_network_timeout`].
+pub const DEFAULT_RECV_POLL_INTERVAL_MS: u64 = 3_000;
 
-/// The height of the internal queue. This represents the maximum number of elements that a queue
-/// can accommodate without losing its oldest elements.
-const MAX_QUEUE_ELEMENTS: usize = 300;
+/// Default capacity of the internal network event queue. When full the oldest event is
+/// evicted. Configurable via [`CoreBuilder::with_event_queue_capacity`].
+pub const DEFAULT_EVENT_QUEUE_CAPACITY: usize = 300;
 
 /// Type that represents the response of the network layer to the application layer's event handler.
 pub type AppResponseResult = Result<AppResponse, NetworkError>;
@@ -589,6 +591,10 @@ pub(super) struct NetworkInfo {
 	pub replication: replication::ReplInfo,
 	/// Important information to manage `sharding` operations.
 	pub sharding: sharding::ShardingInfo,
+	/// Maximum number of polls in `recv_from_network` before returning `NetworkReadTimeout`.
+	pub network_recv_max_polls: usize,
+	/// Milliseconds to sleep between each poll in `recv_from_network`.
+	pub network_recv_poll_interval_ms: u64,
 }
 
 /// Module that contains important data structures to manage `Ping` operations on the network.
@@ -680,8 +686,13 @@ pub mod gossipsub_cfg {
 }
 
 /// Queue that stores and removes data in a FIFO manner.
+///
+/// When the queue reaches its configured `capacity` the oldest element is evicted to make
+/// room for the new one.  Use [`DataQueue::with_capacity`] to override the default of
+/// [`DEFAULT_EVENT_QUEUE_CAPACITY`].
 #[derive(Clone)]
 pub(super) struct DataQueue<T: Debug + Clone + Eq + PartialEq + Hash> {
+	capacity: usize,
 	buffer: Arc<Mutex<VecDeque<T>>>,
 }
 
@@ -689,15 +700,16 @@ impl<T> DataQueue<T>
 where
 	T: Debug + Clone + Eq + PartialEq + Hash,
 {
-	/// The initial buffer capacity, to optimize for speed and defer allocation
-	const INITIAL_BUFFER_CAPACITY: usize = 300;
-
-	/// Create new queue.
+	/// Create a new queue with the default capacity ([`DEFAULT_EVENT_QUEUE_CAPACITY`]).
 	pub fn new() -> Self {
+		Self::with_capacity(DEFAULT_EVENT_QUEUE_CAPACITY)
+	}
+
+	/// Create a new queue with an explicit `capacity`.
+	pub fn with_capacity(capacity: usize) -> Self {
 		Self {
-			buffer: Arc::new(Mutex::new(VecDeque::with_capacity(
-				DataQueue::<T>::INITIAL_BUFFER_CAPACITY,
-			))),
+			capacity,
+			buffer: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
 		}
 	}
 
@@ -706,10 +718,10 @@ where
 		self.buffer.lock().await.pop_front()
 	}
 
-	/// Append an item to the queue.
+	/// Append an item to the queue, evicting the oldest entry if capacity is reached.
 	pub async fn push(&self, item: T) {
 		let mut buffer = self.buffer.lock().await;
-		if buffer.len() >= MAX_QUEUE_ELEMENTS {
+		if buffer.len() >= self.capacity {
 			buffer.pop_front();
 		}
 		buffer.push_back(item);

--- a/swarm-nl/src/core/replication.rs
+++ b/swarm-nl/src/core/replication.rs
@@ -549,12 +549,19 @@ impl ReplicaBufferQueue {
 				let _ = core.query_network(gossip_request).await;
 			}
 
-			// Wait for a defined duration before the next sync
+			// Use the configured sync_wait_time so that callers using
+			// ReplNetworkConfig::Custom with a short interval are honoured.
+			// Previously this always used the hardcoded SYNC_WAIT_TIME constant (5 s).
+			let sync_wait_time = match self.config {
+				ReplNetworkConfig::Default => Self::SYNC_WAIT_TIME,
+				ReplNetworkConfig::Custom { sync_wait_time, .. } => sync_wait_time,
+			};
+
 			#[cfg(feature = "tokio-runtime")]
-			tokio::time::sleep(Duration::from_secs(Self::SYNC_WAIT_TIME)).await;
+			tokio::time::sleep(Duration::from_secs(sync_wait_time)).await;
 
 			#[cfg(feature = "async-std-runtime")]
-			async_std::task::sleep(Duration::from_secs(Self::SYNC_WAIT_TIME)).await;
+			async_std::task::sleep(Duration::from_secs(sync_wait_time)).await;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Four general-purpose improvements extracted from the `ds-swarm` drone-swarm integration, each a good upstream candidate.

- **Configurable `recv_from_network` polling** (`prelude.rs`, `mod.rs`): replaces hardcoded `NETWORK_READ_TIMEOUT = 30 s` / `TASK_SLEEP_DURATION = 3 s` with `CoreBuilder::with_network_timeout(max_polls, poll_interval_ms)`. Defaults are identical to the old behaviour (10 × 3 000 ms = 30 s). Also fixes the `MutexGuard` being held across the sleep call, which blocked other tasks from writing responses.

- **Configurable event queue capacity** (`prelude.rs`, `mod.rs`): `DataQueue` previously had a hardcoded capacity of 300. Added `DataQueue::with_capacity()` and `CoreBuilder::with_event_queue_capacity()`. Default unchanged.

- **Fix: `ReplNetworkConfig::Custom` `sync_wait_time` ignored** (`replication.rs`): `sync_with_eventual_consistency` was always sleeping `SYNC_WAIT_TIME` (5 s) regardless of the user-supplied value. Now reads `sync_wait_time` from `self.config`, matching the pattern used for `data_aging_period` in the same function.

- **`Core::shutdown()`** (`mod.rs`): stores `AbortHandle`s for the two background tasks spawned by `build()` in a shared `Arc<Mutex<Vec<AbortHandle>>>`. `Core::shutdown()` aborts them, releasing the libp2p Swarm and its TCP/UDP listeners immediately — enabling port reuse in tests and graceful restarts. Tokio-runtime only, no behaviour change unless `shutdown()` is called.

## Test plan

- [ ] `cargo check --features tokio-runtime` passes (verified clean)
- [ ] Confirm defaults are unchanged: `with_network_timeout` not called → 30 s ceiling as before
- [ ] Confirm `with_event_queue_capacity` not called → queue capacity 300 as before
- [ ] Confirm `ReplNetworkConfig::Default` → `sync_wait_time` still 5 s
- [ ] Call `core.shutdown().await` after `GossipsubExitNetwork` and verify port is released for re-use

🤖 Generated with [Claude Code](https://claude.com/claude-code)